### PR TITLE
feat(function): tap utility

### DIFF
--- a/src/function.test.ts
+++ b/src/function.test.ts
@@ -1,0 +1,6 @@
+import { tap } from './function'
+
+it('function', () => {
+  expect(tap(1, value => value++)).toEqual(1)
+  expect(tap({ a: 1 }, obj => obj.a++)).toEqual({ a: 2 })
+})

--- a/src/function.test.ts
+++ b/src/function.test.ts
@@ -1,6 +1,6 @@
 import { tap } from './function'
 
-it('function', () => {
+it('tap', () => {
   expect(tap(1, value => value++)).toEqual(1)
   expect(tap({ a: 1 }, obj => obj.a++)).toEqual({ a: 2 })
 })

--- a/src/function.ts
+++ b/src/function.ts
@@ -15,7 +15,14 @@ export function invoke(fn: Fn) {
 }
 
 /**
- * Pass the value through the callback, and return the former.
+ * Pass the value through the callback, and return the value.
+ *
+ * @example
+ * function createUser(name: string): User {
+ *   return tap(new User, user => {
+ *     user.name = name
+ *   })
+ * }
  */
 export function tap<T>(value: T, callback: (value: T) => void): T {
   callback(value)

--- a/src/function.ts
+++ b/src/function.ts
@@ -18,11 +18,13 @@ export function invoke(fn: Fn) {
  * Pass the value through the callback, and return the value.
  *
  * @example
+ * ```
  * function createUser(name: string): User {
  *   return tap(new User, user => {
  *     user.name = name
  *   })
  * }
+ * ```
  */
 export function tap<T>(value: T, callback: (value: T) => void): T {
   callback(value)

--- a/src/function.ts
+++ b/src/function.ts
@@ -13,3 +13,11 @@ export function batchInvoke(functions: Nullable<Fn>[]) {
 export function invoke(fn: Fn) {
   return fn()
 }
+
+/**
+ * Pass the value through the callback, and return the former.
+ */
+export function tap<T>(value: T, callback: (value: T) => void): T {
+  callback(value)
+  return value
+}


### PR DESCRIPTION
This PR adds a new utility function, `tap`. This is a common utility found in ecosystems like [Laravel](https://laravel.com/docs/8.x/helpers#method-tap) or [Ruby](https://apidock.com/ruby/Object/tap). Underscore has [an implementation](https://underscorejs.org/docs/modules/tap.html) as well. 

The concept is fairly simple: you give a value as the first argument to `tap`, and a callback as the second argument. The callback takes the value as a parameter, and is executed just before `tap` returns the initial value. 

This is useful for avoiding temporary variables: 

```ts
// Without tap
function createUser(name: string, age: number) {
  const user = new User()
  user.name = name
  user.age = age

  return user
}

// With tap
function createUser(name: string, age: number) {
  return tap(new User, user => {
    user.name = name
    user.age = age
  })
}
```

This is the first example that came to my mind, and as you can see, the trade-off `tap` offers to avoid declaring a variable is a little bit or readability. Sometimes, it's better not to use it, but most of the times, I find it super useful.