### PR TITLE
feat(base): assertion function type guard

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -1,3 +1,5 @@
-export const assert = (condition: boolean, ...infos: any[]) => { if (!condition) throw new Error(...infos) }
+export const assert = (condition: boolean, message: string): asserts condition => {
+  if (!condition) throw new Error(message)
+}
 export const toString = Object.prototype.toString
 export const noop = () => {}


### PR DESCRIPTION
- Use assertion function syntax to let TypeScript know the condition is handled. Otherwise TypeScript will throw erros like "this variable may be undefined" etc.
- I believe the `ErrorConstructor` can handle only one argument, the `message` string.