### PR TITLE
fix: objectKeys return type

### DIFF
--- a/src/object.ts
+++ b/src/object.ts
@@ -55,7 +55,7 @@ export function isKeyOf<T extends object>(obj: T, k: keyof any): k is keyof T {
  * @category Object
  */
 export function objectKeys<T extends object>(obj: T) {
-  return Object.keys(obj) as Array<keyof T>
+  return Object.keys(obj) as Array<`${keyof T & (string | number | boolean | null | undefined)}`>
 }
 
 /**


### PR DESCRIPTION
Hello! Sorry for opening up a PR without first creating an issue. I ran into a problem with my own implementation of objectKeys, and came to this repo to check how it was implemented, and therefore, I'm proposing this simple fix so the types are more accurate.

### Description

Object.keys returns all keys as string, therefore, it cannot return a type that doesn't extend string.

