### PR TITLE
fix(array): `toArray` - convert to empty array only for nullish

### DIFF
--- a/src/array.test.ts
+++ b/src/array.test.ts
@@ -1,5 +1,20 @@
-import { expect, it } from 'vitest'
-import { flattenArrayable, partition, range } from './array'
+import { describe, expect, it } from 'vitest'
+import { flattenArrayable, partition, range, toArray } from './array'
+
+describe('toArray', () => {
+  it.each([
+    [undefined, []],
+    [null, []],
+    [false, [false]],
+    [0, [0]],
+    ['', ['']],
+    [[], []],
+    ['foo', ['foo']],
+    [['foo'], ['foo']],
+  ])('%s => %s', (input, expected) => {
+    expect(toArray(input)).toEqual(expected)
+  })
+})
 
 it('flattenArrayable', () => {
   expect(flattenArrayable()).toEqual([])

--- a/src/array.ts
+++ b/src/array.ts
@@ -7,10 +7,8 @@ import type { Arrayable, Nullable } from './types'
  * @category Array
  */
 export function toArray<T>(array?: Nullable<Arrayable<T>>): Array<T> {
-  array = array || []
-  if (Array.isArray(array))
-    return array
-  return [array]
+  array = array ?? []
+  return Array.isArray(array) ? array : [array]
 }
 
 /**


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Based on the `Nullable` type of the argument, it looks like we only want to convert `null` and `undefined` into empty array. But in the current logic, falsy values (such as `0`, `false`, `''`, etc.) are also being converted. It is probably better to respect these values. 

If there is a good reason to bypass the falsy values, please feel free to close this PR.

### Linked Issues

NA

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

I think we should take advantage of `it.each` for looping through test cases 
- `input` and `expected (output)` of test cases are grouped in the same format `[input, expected]`
- Avoid code repetition for the test implementation.

I have added test cases for `toArray` function as the demo
