### PR TITLE
fix: export `equal`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export * from './array'
 export * from './base'
+export * from './equal'
 export * from './guards'
 export * from './is'
 export * from './math'


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

I was trying to import isDeepEqual from the package and noticed it wasn't exported.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
