### PR TITLE
fix(object): the return type of objectMap should be the return type o…

### DIFF
--- a/src/object.ts
+++ b/src/object.ts
@@ -29,12 +29,12 @@ import type { DeepMerge } from './types'
  * // { b: 2 }
  * ```
  */
-export function objectMap<K extends string, V, NK = K, NV = V>(obj: Record<K, V>, fn: (key: K, value: V) => [NK, NV] | undefined): Record<K, V> {
+export function objectMap<K extends string, V, NK extends string | number | symbol = K, NV = V>(obj: Record<K, V>, fn: (key: K, value: V) => [NK, NV] | undefined): Record<NK, NV> {
   return Object.fromEntries(
     Object.entries(obj)
       .map(([k, v]) => fn(k as K, v as V))
       .filter(notNullish),
-  )
+  ) as Record<NK, NV>
 }
 
 /**


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

It fixed the return type issue of  `objectMap`.

Before:

```ts
const val = objectMap({ one: 1, two: 2 }, (k, v) => [k, `${v}`]) // { one: '1', two: '2' }
// type of val will be `Record<string, number>`, but it actually is `Record<string, string>`
```

After:

```ts
const val = objectMap({ one: 1, two: 2 }, (k, v) => [k, `${v}`]) // { one: '1', two: '2' }
// type of val is `Record<string, string>`
```

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

Fixes #45

### Additional context

I have to assert the type of return value because it cannot be compatible with `{ [k: string]: NV; }` and `Record<NK, NV>` and I have no idea how to fix it.

<!-- e.g. is there anything you'd like reviewers to focus on? -->
