### PR TITLE
types(function): `invoke` infer the invoked fn's return type

### DIFF
--- a/src/function.ts
+++ b/src/function.ts
@@ -8,9 +8,9 @@ export function batchInvoke(functions: Nullable<Fn>[]) {
 }
 
 /**
- * Call the function
+ * Call the function, returning the result
  */
-export function invoke(fn: Fn) {
+export function invoke<T>(fn: () => T): T {
   return fn()
 }
 


### PR DESCRIPTION
### Description
The current logic allows/already returns the invoked function's result, but the result type is `void`, inferred from `Fn` type, so the `return` is basically meaningless on projects with type-checking.

### Additional context
The `invoke` util that is used in `@vueuse/core` [(here)](https://github.com/vueuse/vueuse/blob/77c795d2e82acc92b9bc0ecc46ff01aa24a0ea2d/packages/shared/utils/index.ts#L64), which is added by @antfu in 2020, infer the invoked fn's type correctly, and I have been using it for years, I just realized the `invoke` in this repo doesn't match the one in `@vueuse` when attempting to use it on a non-Vue project to wrap a logic block into a background promise.

I just copied `@vueuse`'s invoke over.