### PR TITLE
fix: update `then` method signature

### DIFF
--- a/src/p.test.ts
+++ b/src/p.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, expectTypeOf, it } from 'vitest'
 import { p as P } from './p'
 
 const timeout = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
@@ -70,5 +70,12 @@ describe('should', () => {
     catch (e) {
       expect(e).toBeInstanceOf(TypeError)
     }
+  })
+
+  it('should return the correct type', async () => {
+    const p = P([1, 2, 3])
+    expectTypeOf(await p).toEqualTypeOf<number[]>()
+    // @see issue #47
+    expectTypeOf(await p.map(async i => i).map(async i => i)).toEqualTypeOf<number[]>()
   })
 })

--- a/src/p.ts
+++ b/src/p.ts
@@ -79,12 +79,11 @@ class PInstance<T = any> extends Promise<Awaited<T>[]> {
     this.promises.clear()
   }
 
-  then(fn?: () => PromiseLike<any>) {
-    const p = this.promise
-    if (fn)
-      return p.then(fn)
-    else
-      return p
+  then<TResult1 = Awaited<T>[], TResult2 = never>(
+    onfulfilled?: ((value: Awaited<T>[]) => TResult1 | PromiseLike<TResult1>) | null,
+    onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null,
+  ) {
+    return this.promise.then(onfulfilled, onrejected)
   }
 
   catch(fn?: (err: unknown) => PromiseLike<any>) {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR fixes a type inference issue described in [Issue #47](https://github.com/antfu/utils/issues/47). When chaining methods like `map` on a `PInstance`, the type resolved by `await` has been erroneously inferred as `never`, even though the runtime value is correct.

#### The Issue

The problem also affects direct awaits like `await PInstance([1, 2])`. On investigation, the cause was tracked to the custom `then` method implementation in `PInstance`. The current `then` method does not include a full generic signature matching that of the native `Promise.then`, which prevents TypeScript from properly inferring the awaited type.

#### The Fix

This PR updates the `then` method to include all the necessary generics and to strictly align with the native Promise interface. With this change, awaiting a `PInstance` will correctly resolve to `Awaited<T>[]` instead of `never`, which fixes the type inference issue.

### Linked Issues

try resolves #47 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

I'm not completely sure about the reasoning behind that design choice, so I would appreciate some clarification on whether this change aligns with your original intent and the overall design goals for the library.
