### PR TITLE
feat(object): new `objectOmit` function

### DIFF
--- a/src/object.ts
+++ b/src/object.ts
@@ -191,6 +191,17 @@ export function objectPick<O extends object, T extends keyof O>(obj: O, keys: T[
 }
 
 /**
+ * Create a new subset object by omit giving keys
+ *
+ * @category Object
+ */
+export function objectOmit<O extends object, T extends keyof O>(obj: O, keys: T[], omitUndefined = false) {
+  return Object.fromEntries(Object.entries(obj).filter(([key, value]) => {
+    return (!omitUndefined || value !== undefined) && !keys.includes(key as T)
+  })) as Omit<O, T>
+}
+
+/**
  * Clear undefined fields from an object. It mutates the object
  *
  * @category Object


### PR DESCRIPTION
### Description

I've been running into some cases where I needed `objectOmit` from time to time, would be great if our favorite utils package have it too.

### Linked Issues


### Additional context

The function was simply copied over from `vueuse/packages/shared/utils/general.ts`, adding the `@category` tag.
